### PR TITLE
Retry api calls

### DIFF
--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -19,19 +19,7 @@
 
 	<application android:allowBackup="true"
 		android:label="@string/app_name"
-		android:supportsRtl="true"
-		>
-
-
-		<receiver
-			android:name="com.tendarts.sdk.gcm.DartsReceiver"
-			>
-			<intent-filter>
-				<action android:name="com.darts.sdk.CLEAR_PUSHES"/>
-				<action android:name="com.darts.sdk.OPEN_PUSH" />
-				<action android:name="com.darts.sdk.OPEN_LIST"/>
-			</intent-filter>
-		</receiver>
+		android:supportsRtl="true">
 
 		<service
 			android:name=".communications.PendingCommunicationsService"

--- a/sdk/src/main/java/com/tendarts/sdk/Model/PersistentPush.java
+++ b/sdk/src/main/java/com/tendarts/sdk/Model/PersistentPush.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import com.tendarts.sdk.client.TendartsClient;
 import com.tendarts.sdk.common.Configuration;
 import com.tendarts.sdk.common.PushController;
+import com.tendarts.sdk.gcm.DartsReceiver;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -152,7 +153,7 @@ public class PersistentPush
 			return null;
 		}
 
-		backIntent.setAction("com.darts.sdk.OPEN_PUSH");
+		backIntent.setAction(DartsReceiver.OPEN_PUSH);
 		// backIntent.putExtra("dismiss", not_id);
 		backIntent.putExtra("sorg",accessToken.hashCode());
 		push.serializeToExtras(backIntent);

--- a/sdk/src/main/java/com/tendarts/sdk/TendartsSDK.java
+++ b/sdk/src/main/java/com/tendarts/sdk/TendartsSDK.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -30,6 +31,7 @@ import com.tendarts.sdk.common.Util;
 import com.tendarts.sdk.communications.Communications;
 import com.tendarts.sdk.communications.ICommunicationObserver;
 import com.tendarts.sdk.communications.PendingCommunicationsService;
+import com.tendarts.sdk.gcm.DartsReceiver;
 import com.tendarts.sdk.gcm.GCMListenerService;
 import com.tendarts.sdk.gcm.GCMRegistrationIntentService;
 import com.tendarts.sdk.geo.GoogleUpdates;
@@ -773,6 +775,7 @@ public class TendartsSDK
 
 		PendingCommunicationsService.startPendingCommunications(activity.getApplicationContext());
 
+		registerDartsReceiver(activity.getApplicationContext());
 
 	}//onCreate
 
@@ -1670,6 +1673,17 @@ public class TendartsSDK
 		 * @param parent could be null.
 		 */
 		void alertNotEnabled(Activity parent);
+	}
+
+	private static void registerDartsReceiver(Context context) {
+
+		DartsReceiver dartsReceiver = new DartsReceiver();
+
+		IntentFilter filter = new IntentFilter();
+		filter.addAction(DartsReceiver.CLEAR_PUSHES);
+		filter.addAction(DartsReceiver.OPEN_PUSH);
+		filter.addAction(DartsReceiver.OPEN_LIST);
+		context.registerReceiver(dartsReceiver, filter);
 	}
 
 }

--- a/sdk/src/main/java/com/tendarts/sdk/client/TendartsClient.java
+++ b/sdk/src/main/java/com/tendarts/sdk/client/TendartsClient.java
@@ -12,6 +12,7 @@ import com.tendarts.sdk.Model.Notification;
 import com.tendarts.sdk.Model.PersistentPush;
 import com.tendarts.sdk.TendartsSDK;
 import com.tendarts.sdk.common.Configuration;
+import com.tendarts.sdk.gcm.DartsReceiver;
 
 import java.security.InvalidParameterException;
 
@@ -126,7 +127,7 @@ public abstract   class TendartsClient extends BroadcastReceiver implements INot
 			String action = intent.getAction();
 
 
-			if ("com.darts.sdk.CLEAR_PUSHES".equalsIgnoreCase(action))
+			if (DartsReceiver.CLEAR_PUSHES.equalsIgnoreCase(action))
 			{
 
 				PersistentPush.clear(context);

--- a/sdk/src/main/java/com/tendarts/sdk/gcm/DartsReceiver.java
+++ b/sdk/src/main/java/com/tendarts/sdk/gcm/DartsReceiver.java
@@ -8,20 +8,12 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 
-
-import com.tendarts.sdk.Model.PersistentPush;
 import com.tendarts.sdk.Model.Notification;
+import com.tendarts.sdk.Model.PersistentPush;
 import com.tendarts.sdk.TendartsSDK;
 import com.tendarts.sdk.client.TendartsClient;
 import com.tendarts.sdk.common.Configuration;
-import com.tendarts.sdk.common.Constants;
-import com.tendarts.sdk.common.Util;
-import com.tendarts.sdk.communications.Communications;
-import com.tendarts.sdk.communications.ICommunicationObserver;
 import com.tendarts.sdk.monitoring.IntentMonitorService;
-
-
-import org.json.JSONObject;
 
 /**
  * Created by jorgearimany on 19/4/17.
@@ -30,25 +22,23 @@ import org.json.JSONObject;
 public class DartsReceiver extends BroadcastReceiver
 {
 
-
 	private static final String TAG = "DartsReceiver";
+
+	public static final String CLEAR_PUSHES = "com.darts.sdk.CLEAR_PUSHES";
+	public static final String OPEN_PUSH = "com.darts.sdk.OPEN_PUSH";
+	public static final String OPEN_LIST = "com.darts.sdk.OPEN_LIST";
 
 	static Thread thread;
 
 	@Override
-	public void onReceive(final Context context, final Intent intent)
-	{
+	public void onReceive(final Context context, final Intent intent)  {
 
-
-		if(intent!=null){
-
-
+		if(intent != null) {
 
 			String action = intent.getAction();
 
 			Bundle extras = intent.getExtras();
-			if( extras == null|| !extras.containsKey("sorg") )
-			{
+			if( extras == null || !extras.containsKey("sorg")) {
 				Log.e(TAG, "onReceive: no extras");
 				return;
 			}
@@ -68,7 +58,7 @@ public class DartsReceiver extends BroadcastReceiver
 				return;
 			}
 
-			if( "com.darts.sdk.CLEAR_PUSHES".equalsIgnoreCase(action))
+			if( CLEAR_PUSHES.equalsIgnoreCase(action))
 			{
 
 				PersistentPush.clear(context);
@@ -86,7 +76,7 @@ public class DartsReceiver extends BroadcastReceiver
 
 				return;
 			}
-			else if ("com.darts.sdk.OPEN_PUSH".equalsIgnoreCase(action))
+			else if (OPEN_PUSH.equalsIgnoreCase(action))
 			{
 				//open push
 				if( Notification.canDeserialize(intent))
@@ -142,14 +132,12 @@ public class DartsReceiver extends BroadcastReceiver
 					Log.d(TAG, "onReceive: can't deserialize");
 				}
 			}
-			else if("com.darts.sdk.OPEN_LIST".equalsIgnoreCase(action))
+			else if(OPEN_LIST.equalsIgnoreCase(action))
 			{
 				dismissNotificationIfNeeded(context, intent);
 
 				TendartsClient.instance(context).openNotificationList(context);
 			}
-
-
 
 		}
 	}


### PR DESCRIPTION
Register DartsReceiver using 'Context.registerReceiver()' instead of the manifest to support API >= 26.
Small refactor in DartsReceiver.